### PR TITLE
add awesome-bot and dangerCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+rvm: 2.2
+cache: bundler
+before_script:
+  - gem install awesome_bot
+  - gem install danger
+script:
+  - awesome_bot README.md --allow-dupe --allow-ssl --allow 403,429 --allow-redirect -w linkedin
+after_script:
+  - danger || exit 0

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,8 @@
+# Check links
+require 'json'
+results = File.read 'ab-results-README.md-markdown-table.json'
+j = JSON.parse results
+if j['error']==true
+  fail j['title']
+  markdown j['message']
+end


### PR DESCRIPTION
This adds automatic link checking with awesome-bot framework ran on travis-ci.

I have also added optional [danger](https://github.com/danger/danger) support. To enable it, just add your github access token to environment variable named DANGER_GITHUB_API_TOKEN in travis ci pipeline. It needs basic access token permission named `public_repo`. Link for adding tokens: https://github.com/settings/tokens/new
If enabled Danger would post comment under PR when something is wrong with links provided in README.md