### PR TITLE
official demo-site

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Prometheus is an open-source systems monitoring and alerting toolkit.
 
 - [Prometheus Monitoring subreddit](https://www.reddit.com/r/PrometheusMonitoring/) - Subreddit collecting all Prometheus-related resources on the internet.
 - [PromCon](https://promcon.io/) - The Prometheus conference.
-- [Prometheus demo site](http://demo.cloudalchemy.org:9090) - Prometheus site managed with ansible running every day using playbook from [cloudalchemy repository](https://github.com/cloudalchemy/demo-site).
+- [Official prometheus demo site](https://demo.do.prometheus.io) - Prometheus site managed with cloudalchemy ansible roles running every day using configuration from [prometheus repository](https://github.com/prometheus/demo-site).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Prometheus is an open-source systems monitoring and alerting toolkit.
 
 - [Prometheus Monitoring subreddit](https://www.reddit.com/r/PrometheusMonitoring/) - Subreddit collecting all Prometheus-related resources on the internet.
 - [PromCon](https://promcon.io/) - The Prometheus conference.
-- [Official prometheus demo site](https://demo.do.prometheus.io) - Prometheus site managed with cloudalchemy ansible roles running every day using configuration from [prometheus repository](https://github.com/prometheus/demo-site).
+- [Official Prometheus demo site](https://demo.do.prometheus.io) - Prometheus site managed with Cloud Alchemy Ansible roles running every day using configuration from [Prometheus repository](https://github.com/prometheus/demo-site).
 
 ## License
 


### PR DESCRIPTION
Cloualchemy demo site was decommissioned and it now lives as an official prometheus demo site.