### PR TITLE
move demo-site, add monitoring-mixins, add cloudalchemy ansible roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Prometheus is an open-source systems monitoring and alerting toolkit.
 - [GitHub repository](https://github.com/prometheus/prometheus) - Prometheus' source code, issues discussion and collaboration.
 - [Documentation](https://prometheus.io/docs/introduction/overview/) - Official Prometheus documentation.
 - [Blog](https://prometheus.io/blog/) - Official Prometheus blog.
+- [Demo site](https://demo.do.prometheus.io) - Official prometheus demo site managed by Cloud Alchemy Ansible roles updating daily using configuration from [Prometheus repository](https://github.com/prometheus/demo-site).
 
 ## Tutorials
 
@@ -105,6 +106,7 @@ Prometheus is an open-source systems monitoring and alerting toolkit.
 ## Deployment tools
 
 - [Ansitheus](https://github.com/ntk148v/ansitheus) - Ansible playbook to containerize, configure and deploy Prometheus ecosystem _by ntk148v_.
+- [Cloud Alchemy ansible roles](https://github.com/cloudalchemy) - Ansible roles to manage prometheus, alertmanager, grafana, and commond prometheus exporters.
 - [Ansible-prometheus](https://github.com/ernestas-poskus/ansible-prometheus) - Ansible playbook for installing Prometheus monitoring system, exporters such as: node, snmp, blackbox, thus alert manager and push gateway _by Ernestas Poskus_.
 - [Click-to-deploy Prometheus](https://github.com/GoogleCloudPlatform/click-to-deploy/tree/master/k8s/prometheus) - Source for Google Click to Deploy Prometheus solutions listed on Google Cloud Marketplace _by GoogleCloudPlatform_.
 - [Prometheus Operator](https://github.com/coreos/prometheus-operator) - Prometheus Operator creates/configures/manages Prometheus clusters atop Kubernetes _by CoreOS_.
@@ -127,6 +129,7 @@ Prometheus is an open-source systems monitoring and alerting toolkit.
 
 ## Alertmanager
 
+- [Monitoring mixins](https://monitoring.mixins.dev) - Community managed bundles of alerts, recording rules, and grafana dashboards.
 - [Awesome Prometheus Alerting Rules](https://github.com/samber/awesome-prometheus-alerts) - Awesome List of Prometheus alerting rules.
 - [Karma](https://github.com/prymitive/karma) - Alert dashboard for Prometheus Alertmanager.
 
@@ -146,7 +149,7 @@ Prometheus is an open-source systems monitoring and alerting toolkit.
 
 - [Prometheus Monitoring subreddit](https://www.reddit.com/r/PrometheusMonitoring/) - Subreddit collecting all Prometheus-related resources on the internet.
 - [PromCon](https://promcon.io/) - The Prometheus conference.
-- [Official Prometheus demo site](https://demo.do.prometheus.io) - Prometheus site managed with Cloud Alchemy Ansible roles running every day using configuration from [Prometheus repository](https://github.com/prometheus/demo-site).
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Prometheus is an open-source systems monitoring and alerting toolkit.
 
 ## Alertmanager
 
-- [Monitoring mixins](https://monitoring.mixins.dev) - Community managed bundles of alerts, recording rules, and grafana dashboards.
+- [Monitoring mixins](https://monitoring.mixins.dev) - Community managed bundles of alerts, recording rules, and Grafana dashboards.
 - [Awesome Prometheus Alerting Rules](https://github.com/samber/awesome-prometheus-alerts) - Awesome List of Prometheus alerting rules.
 - [Karma](https://github.com/prymitive/karma) - Alert dashboard for Prometheus Alertmanager.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Prometheus is an open-source systems monitoring and alerting toolkit.
 - [GitHub repository](https://github.com/prometheus/prometheus) - Prometheus' source code, issues discussion and collaboration.
 - [Documentation](https://prometheus.io/docs/introduction/overview/) - Official Prometheus documentation.
 - [Blog](https://prometheus.io/blog/) - Official Prometheus blog.
-- [Demo site](https://demo.do.prometheus.io) - Official prometheus demo site managed by Cloud Alchemy Ansible roles updating daily using configuration from [Prometheus repository](https://github.com/prometheus/demo-site).
+- [Official Prometheus demo](https://demo.do.prometheus.io) - Official Prometheus demo site managed by Cloud Alchemy Ansible roles updating daily using configuration from [Prometheus repository](https://github.com/prometheus/demo-site).
 
 ## Tutorials
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Prometheus is an open-source systems monitoring and alerting toolkit.
 ## Deployment tools
 
 - [Ansitheus](https://github.com/ntk148v/ansitheus) - Ansible playbook to containerize, configure and deploy Prometheus ecosystem _by ntk148v_.
-- [Cloud Alchemy ansible roles](https://github.com/cloudalchemy) - Ansible roles to manage prometheus, alertmanager, grafana, and commond prometheus exporters.
+- [Cloud Alchemy Ansible roles](https://github.com/cloudalchemy) - Ansible roles to manage Prometheus, Alertmanager, Grafana, and commond Prometheus exporters.
 - [Ansible-prometheus](https://github.com/ernestas-poskus/ansible-prometheus) - Ansible playbook for installing Prometheus monitoring system, exporters such as: node, snmp, blackbox, thus alert manager and push gateway _by Ernestas Poskus_.
 - [Click-to-deploy Prometheus](https://github.com/GoogleCloudPlatform/click-to-deploy/tree/master/k8s/prometheus) - Source for Google Click to Deploy Prometheus solutions listed on Google Cloud Marketplace _by GoogleCloudPlatform_.
 - [Prometheus Operator](https://github.com/coreos/prometheus-operator) - Prometheus Operator creates/configures/manages Prometheus clusters atop Kubernetes _by CoreOS_.


### PR DESCRIPTION
Few changes in one PR. I can separate them if necessary.

- Moved demo-site link from "Uncategorized" to "Official resources"
- Added link to cloudalchemy ansible roles as a deployment scenario as those are also [recommended by prometheus docs](https://prometheus.io/docs/prometheus/latest/installation/#using-configuration-management-systems)
- Added link to monitoring mixins - a prometheus community standard for sharing alerts, recording rules, and grafana dashboards in one reusable bundle. Mixins are shipped for example by [prometheus](https://github.com/prometheus/prometheus/tree/master/documentation/prometheus-mixin), [node_exporter](https://github.com/prometheus/node_exporter/tree/master/docs/node-mixin), and others