### PR TITLE
Update README.md - Add Pushgateway-Exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The lists below contain all the official Prometheus exporters that are maintaine
 - [Trickster](https://github.com/tricksterproxy/trickster) - HTTP reverse proxy/cache for HTTP applications and a dashboard query accelerator for time series databases.
 - [exporter_proxy](https://github.com/mrichar1/exporter_proxy) - A tiny, simple pure-python reverse-proxy for Prometheus exporters, with TLS support.
 - [PromQL Guard](https://github.com/kfdm/promql-guard) - Provides a thin proxy on top of Prometheus, that allows PromQL queries to be inspected and re-written, so that a tenant can only see allowed data, even when using a shared Prometheus server.
+- [Pushgateway Exporter](https://github.com/oboroworks/pushgateway-exporter) - Make *pushgateway* services notifications available for probing as in Blackbox Exporter.
 
 ## High Availability
 - [Cortex](https://github.com/cortexproject/cortex) - Horizontally scalable, highly available, multi-tenant, long-term Prometheus.


### PR DESCRIPTION
Add Pushgateway-Exporter, a Prometheus bridge between Pushgateway and /probe.