### PR TITLE
Added Cardamon to the list of miscellaneous tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The lists below contain all the official Prometheus exporters that are maintaine
 
 ### Miscellaneous
 - [Blackbox](https://github.com/prometheus/blackbox_exporter) - The Blackbox exporter allows blackbox probing of endpoints over HTTP, HTTPS, DNS, TCP and ICMP.
+- [Cardamon](https://github.com/dominikhei/cardamon) - Cardamon detects unused metrics in Prometheus and generates drop statements to clean them up and reducing your storage.
 
 ## Alertmanager
 - [Monitoring mixins](https://monitoring.mixins.dev) - Community managed bundles of alerts, recording rules, and Grafana dashboards.


### PR DESCRIPTION
I added [cardamon](https://github.com/dominikhei/cardamon) to the list of prometheus tools. 

It gathers all metrics from Grafana dashboards, alert and recording rules and your query logs and then compares this set with the metrics in your TSDB. The unused metrics are displayed in a UI and you can generate drop statements for them.  
